### PR TITLE
Remove hard-coded float type initializations to be typed based on promoted input types.

### DIFF
--- a/src/bSplines/curves.jl
+++ b/src/bSplines/curves.jl
@@ -13,7 +13,7 @@ Convenience function to compute points on a B-spline curve.
 Compute a 1D B-spline curve: given the 'knotVector', the 'controlPoints', and the 'degree', the curve is evaluated at the points given in 'uVector'.
 
 Example for the controlPoints:
-    
+
 P1 = SVector(0.0, 0.0, 0.0)
 P2 = SVector(0.1, 0.25, 0.0)
 P3 = SVector(0.25, 0.3, 0.0)
@@ -21,6 +21,9 @@ P3 = SVector(0.25, 0.3, 0.0)
 controlPoints = [P1, P2, P3]
 """
 function curvePoints(basis::Basis, controlPoints, uVector)
+
+    # Promote input types for initialization
+    T = promote_type(eltype.(controlPoints[:])..., eltype(uVector))
 
     # the number of basis functions is determined by the number of knot vectors and the degree
     nbasisFun = numBasisFunctions(basis)
@@ -30,7 +33,7 @@ function curvePoints(basis::Basis, controlPoints, uVector)
     N = basisFun(spans, uVector, basis)
 
     # determine the curve values
-    curve = [SVector(0.0, 0.0, 0.0) for i in eachindex(uVector)] # initialize
+    curve = [SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector)] # initialize
 
     for (j, span) in enumerate(spans)
         for ind in 1:(basis.degree + 1)
@@ -58,7 +61,7 @@ Convenience function to compute points on all k derivatives of a B-spline curve.
 Compute a points on the k-th derivatives of a B-spline curve: given the 'knotVector', the 'controlPoints', and the 'degree', the curve is evaluated at the points given in 'uVector'.
 
 Example for the controlPoints:
-    
+
 P1 = SVector(0.0, 0.0, 0.0)
 P2 = SVector(0.1, 0.25, 0.0)
 P3 = SVector(0.25, 0.3, 0.0)
@@ -66,6 +69,9 @@ P3 = SVector(0.25, 0.3, 0.0)
 controlPoints = [P1, P2, P3]
 """
 function curveDerivativesPoints(degree::Int, knotVector, controlPoints, uVector, k::Int)
+
+    # Promote input types for initialization
+    T = promote_type(eltype(knotVector), eltype.(controlPoints[:])..., eltype(uVector))
 
     # the number of basis functions is determined by the number of knot vectors and the degree
     nbasisFun = length(knotVector) - degree - 1
@@ -76,7 +82,7 @@ function curveDerivativesPoints(degree::Int, knotVector, controlPoints, uVector,
 
     # determine the curve values
     #curve = [SVector(0.0, 0.0, 0.0) for i in eachindex(uVector)] # initialize
-    curves = [[SVector(0.0, 0.0, 0.0) for i in eachindex(uVector)] for j in 1:(k + 1)]
+    curves = [[SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector)] for j in 1:(k + 1)]
 
     for q in 1:(k + 1)
         for (j, span) in enumerate(spans)

--- a/src/bSplines/surfaces.jl
+++ b/src/bSplines/surfaces.jl
@@ -28,7 +28,10 @@ x / u direction
 """
 function surfacePoints(uBasis::Basis, vBasis::Basis, controlPoints, uVector, vVector)
 
-    # u-direction: determine the basis functions evaluated at uVector 
+    # Promote input types for initialization
+    T = promote_type(eltype.(controlPoints[:])..., eltype(uVector), eltype(vVector))
+
+    # u-direction: determine the basis functions evaluated at uVector
     nbasisFun = numBasisFunctions(uBasis)
     uSpan = findSpan(nbasisFun, uVector, uBasis.knotVec, uBasis.degree)
     Nu = basisFun(uSpan, uVector, uBasis)
@@ -39,7 +42,7 @@ function surfacePoints(uBasis::Basis, vBasis::Basis, controlPoints, uVector, vVe
     Nv = basisFun(vSpan, vVector, vBasis)
 
     # intialize
-    surface = [SVector(0.0, 0.0, 0.0) for i in eachindex(uVector), j in eachindex(vVector)]
+    surface = [SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector), j in eachindex(vVector)]
 
     # determine the surface values
     for uPointInd in eachindex(uVector)
@@ -50,7 +53,7 @@ function surfacePoints(uBasis::Basis, vBasis::Basis, controlPoints, uVector, vVe
 
             for i in 1:(vBasis.degree + 1)
 
-                temp = SVector(0.0, 0.0, 0.0)
+                temp = SVector{3,T}(0.0, 0.0, 0.0)
 
                 vind = vSpan[vPointInd] - vBasis.degree + i - 1
                 for k in 1:(uBasis.degree + 1)
@@ -107,7 +110,10 @@ TODO: implement algorithm A.37 and A.38 of 'The Nurbs book'
 """
 function surfaceDerivativesPoints(uDegree::Int, vDegree::Int, uKnotVector, vKnotVector, controlPoints, uVector, vVector, k::Int)
 
-    # u-direction: determine the basis functions evaluated at uVector 
+    # Promote input types for initialization
+    T = promote_type(eltype(uKnotVector), eltype(vKnotVector), eltype.(controlPoints[:])..., eltype(uVector), eltype(vVector))
+
+    # u-direction: determine the basis functions evaluated at uVector
     nbasisFun = length(uKnotVector) - uDegree - 1
     uSpan = findSpan(nbasisFun, uVector, uKnotVector, uDegree)
     Nu = derBasisFun(uSpan, uDegree, uVector, uKnotVector, k)
@@ -118,7 +124,7 @@ function surfaceDerivativesPoints(uDegree::Int, vDegree::Int, uKnotVector, vKnot
     Nv = derBasisFun(vSpan, vDegree, vVector, vKnotVector, k)
 
     # intialize
-    surfaces = [[SVector(0.0, 0.0, 0.0) for i in eachindex(uVector), j in eachindex(vVector)] for q in 1:(k + 1), p in 1:(k + 1)]
+    surfaces = [[SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector), j in eachindex(vVector)] for q in 1:(k + 1), p in 1:(k + 1)]
 
     # determine the surface derivative values
     for q in 1:(k + 1)
@@ -138,7 +144,10 @@ Compute the q-th derivative along 'u' and the p-th derivative along 'v'.
 """
 function surfaceDerivativesPointsUV(uDegree::Int, vDegree::Int, controlPoints, uVector, vVector, Nu, Nv, q::Int, p::Int, uSpan, vSpan)
 
-    surfaces = [SVector(0.0, 0.0, 0.0) for i in eachindex(uVector), j in eachindex(vVector)]
+    # Promote input types for initialization
+    T = promote_type(eltype.(controlPoints[:])..., eltype(uVector), eltype(vVector))
+
+    surfaces = [SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector), j in eachindex(vVector)]
 
     for uPointInd in eachindex(uVector)
 
@@ -148,7 +157,7 @@ function surfaceDerivativesPointsUV(uDegree::Int, vDegree::Int, controlPoints, u
 
             for i in 1:(vDegree + 1)
 
-                temp = SVector(0.0, 0.0, 0.0)
+                temp = SVector{3,T}(0.0, 0.0, 0.0)
 
                 vind = vSpan[vPointInd] - vDegree + i - 1
                 for kind in 1:(uDegree + 1)

--- a/src/nurbs/curves.jl
+++ b/src/nurbs/curves.jl
@@ -24,6 +24,9 @@ Note: the efficient evaluation via the B-spline basis is employed (no use of the
 """
 function curvePoints(basis::Basis, controlPoints, uVector, weights)
 
+    # Promote input types for initialization
+    T = promote_type(eltype.(controlPoints[:])..., eltype(uVector), eltype(weights))
+
     # the number of basis functions is determined by the number of knot vectors and the degree
     nbasisFun = numBasisFunctions(basis)
 
@@ -32,8 +35,8 @@ function curvePoints(basis::Basis, controlPoints, uVector, weights)
     N = basisFun(spans, uVector, basis)
 
     # determine the curve values
-    curve     = [SVector(0.0, 0.0, 0.0) for i in eachindex(uVector)] # initialize
-    normalize = [0.0 for i in eachindex(uVector)]
+    curve     = [SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector)] # initialize
+    normalize = [T(0.0) for i in eachindex(uVector)]
 
     for (j, span) in enumerate(spans)
         for ind in 1:(basis.degree + 1)
@@ -83,6 +86,9 @@ Note: the efficient evaluation via the B-spline basis is employed (no use of the
 """
 function curveDerivativesPoints(degree::Int, knotVector, controlPoints, uVector, weights, k::Int)
 
+    # Promote input types for initialization
+    T = promote_type(eltype(knotVector), eltype.(controlPoints[:])..., eltype(uVector), eltype(weights))
+
     # the number of basis functions is determined by the number of knot vectors and the degree
     nbasisFun = length(knotVector) - degree - 1
 
@@ -91,8 +97,8 @@ function curveDerivativesPoints(degree::Int, knotVector, controlPoints, uVector,
     N = derBasisFun(spans, degree, uVector, knotVector, k)
 
     # determine the curve values
-    curves    = [[SVector(0.0, 0.0, 0.0) for i in eachindex(uVector)] for q in 1:(k + 1)] # initialize
-    normalize = [0.0 for i in eachindex(uVector)]
+    curves    = [[SVector{3,T}(0.0, 0.0, 0.0) for i in eachindex(uVector)] for q in 1:(k + 1)] # initialize
+    normalize = [T(0.0) for i in eachindex(uVector)]
 
     # --- 0-th derivative
     for (j, span) in enumerate(spans)
@@ -109,7 +115,7 @@ function curveDerivativesPoints(degree::Int, knotVector, controlPoints, uVector,
         curves[1][j] /= normalize[j]
     end
 
-    w = [[0.0 for i in eachindex(uVector)] for q in 1:k]
+    w = [[T(0.0) for i in eachindex(uVector)] for q in 1:k]
 
     # --- q-th derivative
     for q in 1:k

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -227,7 +227,7 @@ Return the Greville sites (as defined in [3]) corresponding to the given knotvec
 function greville(kVec, degree::Int)
 
     N = length(kVec) - degree - 1 # number of B-splines
-    gSites = zeros(N)
+    gSites = zeros(eltype(kVec), N)
 
     for i in 1:N
         gSites[i] = sum(kVec[(i + 1):(i + degree)]) / degree
@@ -248,7 +248,7 @@ Return the anchors (as defined in [4]) corresponding to the given knotvector and
 function anchors(kVec, degree::Int)
 
     N = length(kVec) - degree - 1 # number of B-splines
-    aSites = zeros(N)
+    aSites = zeros(eltype(kVec), N)
 
     for i in 1:N
         aSites[i] = median(kVec[i:(i + degree + 1)])


### PR DESCRIPTION
Changed hard-coded float-types to be parametrically typed based on promoted input types. Mostly in the curves and surfaces files, but also a couple in the utils file.

Tests pass, no functionality has changed. The only difference is that automatic differentiation (for example ForwardDiff Dual types) can now pass through the code.

I noticed other places in the code where initialization types were passed in as an argument.  I suppose that could be done here as well, but the way I've implemented it may be more convenient to the user.  On the other hand, if the most important thing is performance, of NURBS.jl itself, then perhaps passing in the type would be more desirable.  I can make that change, just let me know.